### PR TITLE
Basic config flags

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -338,12 +338,14 @@
                 "Type 2",
                 "Prediabetes"
             ],
-            "default": "t1d"
+            "default": "t1d",
+            "basic_config": true
         },
         "scenario_name_t1d": {
             "title": "Name of the scenario",
             "default": "Example scenario T1D",
-            "$ref": "#/definitions/string"
+            "$ref": "#/definitions/string",
+            "basic_config": true
         },
         "scenario_name_t2d": {
             "title": "Name of the scenario",

--- a/schema.json
+++ b/schema.json
@@ -339,13 +339,13 @@
                 "Prediabetes"
             ],
             "default": "t1d",
-            "basic_config": true
+            "_basic_config": true
         },
         "scenario_name_t1d": {
             "title": "Name of the scenario",
             "default": "Example scenario T1D",
             "$ref": "#/definitions/string",
-            "basic_config": true
+            "_basic_config": true
         },
         "scenario_name_t2d": {
             "title": "Name of the scenario",


### PR DESCRIPTION
_not necessarily for merging_

This PR demonstrates how basic configuration properties can be flagged for front-end use. 

Flags may only be on root level properties, and will by convention be prefixed by an '_'. A property where  `_basic_config` = `false` is equivalent to an unflagged property.

Basic config flags take precedence over [change observer flags](https://github.com/RTIInternational/comprehensive-model-schema/pull/22).