### PR TITLE
Change observer flags

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -660,7 +660,8 @@
                         }
                     }
                 }
-            }
+            },
+            "_watch_for_changes": true
         },
         "SEARCH_risk_factors": {
             "title": " ",

--- a/schema.json
+++ b/schema.json
@@ -876,7 +876,8 @@
                         "default": 0.28
                     }
                 }
-            }
+            },
+            "_watch_for_changes": "Search: Risk Factors"
         },
         "SEARCH_clinical_history": {
             "title": " ",


### PR DESCRIPTION
_not for merging_

This PR contains a demonstration of a change observer flag on a root level property. 

Observer flags operate in conjunction with [basic config flags](https://github.com/RTIInternational/comprehensive-model-schema/pull/21). Properties flagged as basic config flags may not also be change observers, and the basic config flag will take precedence.

Whether these flags will need to be on non-root-level properties is up for discussion. We can implement them if necessary, but the lift on our end will be considerably more so we would like to confirm that they will be implemented.

Flags are prefixed by '_' by convention. A property where  `_watch_for_changes` = `false` is equivalent to an unflagged property. 

If `_watch_for_changes` is `true` or a string, then the scenario summary will notify the user if that section has changed with some identifier for that section. When `true`, the section's identifer defaults to its title, description, or key, in that order (eg. nonexistent or empty values for `title` such as `undefined`, `""`, or `"  "` will prompt the front-end to check that section's `description`). Alternatively, the section can be given a custom identifier string by setting it as the value for `_watch_for_changes`.